### PR TITLE
Fix iter Host method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -88,3 +88,4 @@ Jesse Claven <jesse.claven@gmail.com>
 Derrick Wippler <thrawn01@gmail.com>
 Leigh McCulloch <leigh@leighmcculloch.com>
 Ron Kuris <swcafe@gmail.com>
+Raphael Gavache <raphael.gavache@gmail.com>

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1580,6 +1580,18 @@ func TestQueryStats(t *testing.T) {
 	}
 }
 
+// TestIterHosts confirms that host is added to Iter when the query succeeds.
+func TestIterHost(t *testing.T) {
+	session := createSession(t)
+	defer session.Close()
+	iter := session.Query("select peer * system.peers").Iter()
+
+	// check if Host method works
+	if iter.Host() != nil {
+		t.Error("No host in iter")
+	}
+}
+
 //TestBatchStats confirms that the stats are returning valid data. Accuracy may be questionable.
 func TestBatchStats(t *testing.T) {
 	if *flagProto == 1 {

--- a/cassandra_test.go
+++ b/cassandra_test.go
@@ -1584,7 +1584,7 @@ func TestQueryStats(t *testing.T) {
 func TestIterHost(t *testing.T) {
 	session := createSession(t)
 	defer session.Close()
-	iter := session.Query("select peer * system.peers").Iter()
+	iter := session.Query("SELECT * FROM system.peers").Iter()
 
 	// check if Host method works
 	if iter.Host() != nil {

--- a/query_executor.go
+++ b/query_executor.go
@@ -48,6 +48,7 @@ func (q *queryExecutor) executeQuery(qry ExecutableQuery) (*Iter, error) {
 
 		// Exit for loop if the query was successful
 		if iter.err == nil {
+			iter.host = host
 			return iter, nil
 		}
 


### PR DESCRIPTION
# Purpose

The function below always return `nil`.
```
// session.go
// Host returns the host which the query was sent to.
1050: func (iter *Iter) Host() *HostInfo {
1051:	return iter.host
1052:}
```

This is because the host is never set in the Iter structure.

# Implementation
Add the host to Iter when the query is executed with success on a host (query_executor.go:50)

Add a test to check if the host is well set on a successful query